### PR TITLE
Update flutter rust bridge dependency in dart and cargo (2.6 -> 2.7)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_rust_bridge: 2.6.0
+  flutter_rust_bridge: 2.7.0
   plugin_platform_interface: ^2.0.2
 
 dev_dependencies:

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-flutter_rust_bridge = "=2.6.0"
+flutter_rust_bridge = "=2.7.0"
 velopack = { version = "0.0", features= ["async"]}
 anyhow = "1.0.86"


### PR DESCRIPTION
This pull request is here to stay up to date with the latest version of flutter rust bridge and prevent version conflict when a project is already using the latest version of FRB and force them to downgrade their local project dependency version.

Thank you for the dart/flutter bindings of velopack! 💪 