### PR TITLE
feat: add release channel support with per-call overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ migrate_working_dir/
 .dart_tool/
 build/
 target/
+
+# FVM Version Cache
+.fvm/
+
+.fvmrc
+.flutter-plugins-dependencies
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.0
+
+* Added release channel support: `initializeVelopack` now accepts an optional `channel` to override the update channel
+* Added a per-call `channel` override to `isUpdateAvailable`, `getLatestUpdateInfo`, `checkAndDownloadUpdatesWithProgress`, `updateAndRestart`, `updateAndExit`, and `waitExitThenUpdate` for checking or pulling from a different channel without re-initializing
+* Added `allowDowngrade` to `initializeVelopack` to permit migrating to an older version when switching channels
+* Fixed potential panic in update download by propagating errors instead of `unwrap()`
+
 ## 0.2.0
 
 * Upgrade Rust Velopack crate to 1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.3.0
 
 * Added release channel support: `initializeVelopack` now accepts an optional `channel` to override the update channel
-* Added a per-call `channel` override to `isUpdateAvailable`, `getLatestUpdateInfo`, `checkAndDownloadUpdatesWithProgress`, `updateAndRestart`, `updateAndExit`, and `waitExitThenUpdate` for checking or pulling from a different channel without re-initializing
+* Added per-call `channel` and `allowDowngrade` overrides to `isUpdateAvailable`, `getLatestUpdateInfo`, `checkAndDownloadUpdatesWithProgress`, `updateAndRestart`, `updateAndExit`, and `waitExitThenUpdate` for checking or pulling from a different channel (including downgrades) without re-initializing
 * Added `allowDowngrade` to `initializeVelopack` to permit migrating to an older version when switching channels
 * Fixed potential panic in update download by propagating errors instead of `unwrap()`
 

--- a/README.md
+++ b/README.md
@@ -60,14 +60,51 @@ This is what Velopack Flutter is doing by setting the following values in `flutt
 
 | Function | Description                                                                                                                  |
 |----------|--------------------------------------------------------------|
-| `initializeVelopack({required String url})` | Initializes the bridge and configures Velopack with the update server URL.                                                      |
-| `isUpdateAvailable()` | Checks if an update is available.                                                                     |
-| `getLatestUpdateInfo()` | Gets detailed information about the latest available update.                                          |
+| `initializeVelopack({required String url, String? channel, bool allowDowngrade = false})` | Initializes the bridge and configures Velopack with the update server URL. Optionally overrides the update `channel` and allows downgrades (see [Channels](#channels)). |
+| `isUpdateAvailable({String? channel})` | Checks if an update is available. Pass `channel` to check a different channel for this call only (see [Channels](#channels)). |
+| `getLatestUpdateInfo({String? channel})` | Gets detailed information about the latest available update. Pass `channel` to query a different channel for this call only. |
 | `currentVersion()` | Returns the current application version as a string.                                                  |
-| `checkAndDownloadUpdatesWithProgress()` | Checks for updates, downloads them, and returns a progress stream.                |
-| `updateAndRestart()` | Applies downloaded updates and restarts the application.                                              |
-| `updateAndExit()` | Applies downloaded updates and exits the application.                                                 |
-| `waitExitThenUpdate({required bool silent, required bool restart})` | Waits for the app to exit, then applies updates. If `restart` is true, the app will restart after applying updates. Use `silent` to suppress UI messages. |
+| `checkAndDownloadUpdatesWithProgress({String? channel})` | Checks for updates, downloads them, and returns a progress stream. Pass `channel` to target a different channel for this call only. |
+| `updateAndRestart({String? channel})` | Applies downloaded updates and restarts the application. Pass `channel` to target a different channel for this call only. |
+| `updateAndExit({String? channel})` | Applies downloaded updates and exits the application. Pass `channel` to target a different channel for this call only. |
+| `waitExitThenUpdate({required bool silent, required bool restart, String? channel})` | Waits for the app to exit, then applies updates. If `restart` is true, the app will restart after applying updates. Use `silent` to suppress UI messages. Pass `channel` to target a different channel for this call only. |
+
+## Channels
+
+Velopack supports release channels (e.g. `staging`, `prod`), set when packaging with `vpk pack ... --channel <name>`. By default an installed app keeps receiving updates from the channel it was installed from — no extra code needed.
+
+To make the app follow a different channel, pass it to `initializeVelopack`:
+
+```dart
+await initializeVelopack(
+  url: 'https://example.com/releases',
+  channel: 'prod',
+);
+```
+
+The channel passed to `initializeVelopack` is the default for every call. To check or pull from a different channel without changing that default, pass `channel` to an individual function:
+
+```dart
+// Peek at what's on the beta channel while staying on the default channel
+final beta = await getLatestUpdateInfo(channel: 'beta');
+
+// Switch over by downloading and applying from beta
+await updateAndRestart(channel: 'beta');
+```
+
+A per-call `channel` overrides the init default for that call only; omit it to use the init default (or the install channel when none was set). Note that downgrades still require `allowDowngrade: true` at init, so switching to a channel whose latest version is older than the installed one needs that opt-in.
+
+The init-level default channel is read once at initialization, so changing *that* default takes effect on the **next launch**. Persist the user's selected channel (e.g. with `shared_preferences`), then restart the app to apply it.
+
+Switching to a channel whose latest version is **older** than the installed version is a downgrade. Velopack ignores downgrades unless you opt in:
+
+```dart
+await initializeVelopack(
+  url: 'https://example.com/releases',
+  channel: 'prod',        // e.g. prod is 1.0.0 while the app is on staging 1.1.0
+  allowDowngrade: true,   // required, otherwise no update is offered
+);
+```
 
 ## Packaging
 

--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ This is what Velopack Flutter is doing by setting the following values in `flutt
 | Function | Description                                                                                                                  |
 |----------|--------------------------------------------------------------|
 | `initializeVelopack({required String url, String? channel, bool allowDowngrade = false})` | Initializes the bridge and configures Velopack with the update server URL. Optionally overrides the update `channel` and allows downgrades (see [Channels](#channels)). |
-| `isUpdateAvailable({String? channel})` | Checks if an update is available. Pass `channel` to check a different channel for this call only (see [Channels](#channels)). |
-| `getLatestUpdateInfo({String? channel})` | Gets detailed information about the latest available update. Pass `channel` to query a different channel for this call only. |
+| `isUpdateAvailable({String? channel, bool? allowDowngrade})` | Checks if an update is available. Pass `channel` / `allowDowngrade` to check a different channel for this call only (see [Channels](#channels)). |
+| `getLatestUpdateInfo({String? channel, bool? allowDowngrade})` | Gets detailed information about the latest available update. Pass `channel` / `allowDowngrade` to query a different channel for this call only. |
 | `currentVersion()` | Returns the current application version as a string.                                                  |
-| `checkAndDownloadUpdatesWithProgress({String? channel})` | Checks for updates, downloads them, and returns a progress stream. Pass `channel` to target a different channel for this call only. |
-| `updateAndRestart({String? channel})` | Applies downloaded updates and restarts the application. Pass `channel` to target a different channel for this call only. |
-| `updateAndExit({String? channel})` | Applies downloaded updates and exits the application. Pass `channel` to target a different channel for this call only. |
-| `waitExitThenUpdate({required bool silent, required bool restart, String? channel})` | Waits for the app to exit, then applies updates. If `restart` is true, the app will restart after applying updates. Use `silent` to suppress UI messages. Pass `channel` to target a different channel for this call only. |
+| `checkAndDownloadUpdatesWithProgress({String? channel, bool? allowDowngrade})` | Checks for updates, downloads them, and returns a progress stream. Pass `channel` / `allowDowngrade` to target a different channel for this call only. |
+| `updateAndRestart({String? channel, bool? allowDowngrade})` | Applies downloaded updates and restarts the application. Pass `channel` / `allowDowngrade` to target a different channel for this call only. |
+| `updateAndExit({String? channel, bool? allowDowngrade})` | Applies downloaded updates and exits the application. Pass `channel` / `allowDowngrade` to target a different channel for this call only. |
+| `waitExitThenUpdate({required bool silent, required bool restart, String? channel, bool? allowDowngrade})` | Waits for the app to exit, then applies updates. If `restart` is true, the app will restart after applying updates. Use `silent` to suppress UI messages. Pass `channel` / `allowDowngrade` to target a different channel for this call only. |
 
 ## Channels
 
@@ -92,11 +92,13 @@ final beta = await getLatestUpdateInfo(channel: 'beta');
 await updateAndRestart(channel: 'beta');
 ```
 
-A per-call `channel` overrides the init default for that call only; omit it to use the init default (or the install channel when none was set). Note that downgrades still require `allowDowngrade: true` at init, so switching to a channel whose latest version is older than the installed one needs that opt-in.
+A per-call `channel` overrides the init default for that call only; omit it to use the init default (or the install channel when none was set).
 
 The init-level default channel is read once at initialization, so changing *that* default takes effect on the **next launch**. Persist the user's selected channel (e.g. with `shared_preferences`), then restart the app to apply it.
 
-Switching to a channel whose latest version is **older** than the installed version is a downgrade. Velopack ignores downgrades unless you opt in:
+### Downgrades
+
+Switching to a channel whose latest version is **older** than the installed version is a downgrade. Velopack ignores downgrades unless you opt in. You can opt in globally at init:
 
 ```dart
 await initializeVelopack(
@@ -105,6 +107,18 @@ await initializeVelopack(
   allowDowngrade: true,   // required, otherwise no update is offered
 );
 ```
+
+…or per call, which overrides the init default for that call only. This pairs with the per-call `channel` so you can preview and switch to an older channel without re-initializing or restarting:
+
+```dart
+// Preview with the same condition the apply will use
+final info = await getLatestUpdateInfo(channel: 'prod', allowDowngrade: true);
+
+// Switch to prod and accept the downgrade, just for this call
+await updateAndRestart(channel: 'prod', allowDowngrade: true);
+```
+
+When `allowDowngrade` is omitted on a call, the init default is used.
 
 ## Packaging
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -365,7 +365,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.0"
+    version: "0.3.0"
   vm_service:
     dependency: transitive
     description:

--- a/lib/src/rust/api/velopack.dart
+++ b/lib/src/rust/api/velopack.dart
@@ -8,30 +8,35 @@ import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These functions are ignored because they are not marked as `pub`: `check_and_download_updates`, `get_update_manager`
+// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `VelopackConfig`
 
-Future<void> initVelopack({required String url}) =>
-    VelopackRustLib.instance.api.crateApiVelopackInitVelopack(url: url);
+Future<void> initVelopack(
+        {required String url, String? channel, required bool allowDowngrade}) =>
+    VelopackRustLib.instance.api.crateApiVelopackInitVelopack(
+        url: url, channel: channel, allowDowngrade: allowDowngrade);
 
-Future<bool> isUpdateAvailable() =>
-    VelopackRustLib.instance.api.crateApiVelopackIsUpdateAvailable();
+Future<bool> isUpdateAvailable({String? channel}) =>
+    VelopackRustLib.instance.api
+        .crateApiVelopackIsUpdateAvailable(channel: channel);
 
-Future<UpdateInfo?> getLatestUpdateInfo() =>
-    VelopackRustLib.instance.api.crateApiVelopackGetLatestUpdateInfo();
+Future<UpdateInfo?> getLatestUpdateInfo({String? channel}) =>
+    VelopackRustLib.instance.api
+        .crateApiVelopackGetLatestUpdateInfo(channel: channel);
 
 Future<String> currentVersion() =>
     VelopackRustLib.instance.api.crateApiVelopackCurrentVersion();
 
-Stream<int> checkAndDownloadUpdatesWithProgress() =>
+Stream<int> checkAndDownloadUpdatesWithProgress({String? channel}) =>
     VelopackRustLib.instance.api
-        .crateApiVelopackCheckAndDownloadUpdatesWithProgress();
+        .crateApiVelopackCheckAndDownloadUpdatesWithProgress(channel: channel);
 
-Future<void> updateAndRestart() =>
-    VelopackRustLib.instance.api.crateApiVelopackUpdateAndRestart();
+Future<void> updateAndRestart({String? channel}) => VelopackRustLib.instance.api
+    .crateApiVelopackUpdateAndRestart(channel: channel);
 
-Future<void> updateAndExit() =>
-    VelopackRustLib.instance.api.crateApiVelopackUpdateAndExit();
+Future<void> updateAndExit({String? channel}) => VelopackRustLib.instance.api
+    .crateApiVelopackUpdateAndExit(channel: channel);
 
 Future<void> waitExitThenUpdate(
-        {required bool silent, required bool restart}) =>
-    VelopackRustLib.instance.api
-        .crateApiVelopackWaitExitThenUpdate(silent: silent, restart: restart);
+        {required bool silent, required bool restart, String? channel}) =>
+    VelopackRustLib.instance.api.crateApiVelopackWaitExitThenUpdate(
+        silent: silent, restart: restart, channel: channel);

--- a/lib/src/rust/api/velopack.dart
+++ b/lib/src/rust/api/velopack.dart
@@ -15,28 +15,39 @@ Future<void> initVelopack(
     VelopackRustLib.instance.api.crateApiVelopackInitVelopack(
         url: url, channel: channel, allowDowngrade: allowDowngrade);
 
-Future<bool> isUpdateAvailable({String? channel}) =>
-    VelopackRustLib.instance.api
-        .crateApiVelopackIsUpdateAvailable(channel: channel);
+Future<bool> isUpdateAvailable({String? channel, bool? allowDowngrade}) =>
+    VelopackRustLib.instance.api.crateApiVelopackIsUpdateAvailable(
+        channel: channel, allowDowngrade: allowDowngrade);
 
-Future<UpdateInfo?> getLatestUpdateInfo({String? channel}) =>
-    VelopackRustLib.instance.api
-        .crateApiVelopackGetLatestUpdateInfo(channel: channel);
+Future<UpdateInfo?> getLatestUpdateInfo(
+        {String? channel, bool? allowDowngrade}) =>
+    VelopackRustLib.instance.api.crateApiVelopackGetLatestUpdateInfo(
+        channel: channel, allowDowngrade: allowDowngrade);
 
 Future<String> currentVersion() =>
     VelopackRustLib.instance.api.crateApiVelopackCurrentVersion();
 
-Stream<int> checkAndDownloadUpdatesWithProgress({String? channel}) =>
+Stream<int> checkAndDownloadUpdatesWithProgress(
+        {String? channel, bool? allowDowngrade}) =>
     VelopackRustLib.instance.api
-        .crateApiVelopackCheckAndDownloadUpdatesWithProgress(channel: channel);
+        .crateApiVelopackCheckAndDownloadUpdatesWithProgress(
+            channel: channel, allowDowngrade: allowDowngrade);
 
-Future<void> updateAndRestart({String? channel}) => VelopackRustLib.instance.api
-    .crateApiVelopackUpdateAndRestart(channel: channel);
+Future<void> updateAndRestart({String? channel, bool? allowDowngrade}) =>
+    VelopackRustLib.instance.api.crateApiVelopackUpdateAndRestart(
+        channel: channel, allowDowngrade: allowDowngrade);
 
-Future<void> updateAndExit({String? channel}) => VelopackRustLib.instance.api
-    .crateApiVelopackUpdateAndExit(channel: channel);
+Future<void> updateAndExit({String? channel, bool? allowDowngrade}) =>
+    VelopackRustLib.instance.api.crateApiVelopackUpdateAndExit(
+        channel: channel, allowDowngrade: allowDowngrade);
 
 Future<void> waitExitThenUpdate(
-        {required bool silent, required bool restart, String? channel}) =>
+        {required bool silent,
+        required bool restart,
+        String? channel,
+        bool? allowDowngrade}) =>
     VelopackRustLib.instance.api.crateApiVelopackWaitExitThenUpdate(
-        silent: silent, restart: restart, channel: channel);
+        silent: silent,
+        restart: restart,
+        channel: channel,
+        allowDowngrade: allowDowngrade);

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -83,24 +83,26 @@ class VelopackRustLib extends BaseEntrypoint<VelopackRustLibApi,
 }
 
 abstract class VelopackRustLibApi extends BaseApi {
-  Stream<int> crateApiVelopackCheckAndDownloadUpdatesWithProgress();
+  Stream<int> crateApiVelopackCheckAndDownloadUpdatesWithProgress(
+      {String? channel});
 
   Future<String> crateApiVelopackCurrentVersion();
 
-  Future<UpdateInfo?> crateApiVelopackGetLatestUpdateInfo();
+  Future<UpdateInfo?> crateApiVelopackGetLatestUpdateInfo({String? channel});
 
   Future<void> crateApiVelopackInitApp();
 
-  Future<void> crateApiVelopackInitVelopack({required String url});
+  Future<void> crateApiVelopackInitVelopack(
+      {required String url, String? channel, required bool allowDowngrade});
 
-  Future<bool> crateApiVelopackIsUpdateAvailable();
+  Future<bool> crateApiVelopackIsUpdateAvailable({String? channel});
 
-  Future<void> crateApiVelopackUpdateAndExit();
+  Future<void> crateApiVelopackUpdateAndExit({String? channel});
 
-  Future<void> crateApiVelopackUpdateAndRestart();
+  Future<void> crateApiVelopackUpdateAndRestart({String? channel});
 
   Future<void> crateApiVelopackWaitExitThenUpdate(
-      {required bool silent, required bool restart});
+      {required bool silent, required bool restart, String? channel});
 }
 
 class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
@@ -113,12 +115,14 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
   });
 
   @override
-  Stream<int> crateApiVelopackCheckAndDownloadUpdatesWithProgress() {
+  Stream<int> crateApiVelopackCheckAndDownloadUpdatesWithProgress(
+      {String? channel}) {
     final progressSink = RustStreamSink<int>();
     unawaited(handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_i_16_Sse(progressSink, serializer);
+        sse_encode_opt_String(channel, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
             funcId: 1, port: port_);
       },
@@ -127,7 +131,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiVelopackCheckAndDownloadUpdatesWithProgressConstMeta,
-      argValues: [progressSink],
+      argValues: [progressSink, channel],
       apiImpl: this,
     )));
     return progressSink.stream;
@@ -137,7 +141,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
       get kCrateApiVelopackCheckAndDownloadUpdatesWithProgressConstMeta =>
           const TaskConstMeta(
             debugName: "check_and_download_updates_with_progress",
-            argNames: ["progressSink"],
+            argNames: ["progressSink", "channel"],
           );
 
   @override
@@ -165,10 +169,11 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
       );
 
   @override
-  Future<UpdateInfo?> crateApiVelopackGetLatestUpdateInfo() {
+  Future<UpdateInfo?> crateApiVelopackGetLatestUpdateInfo({String? channel}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_opt_String(channel, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
             funcId: 3, port: port_);
       },
@@ -177,7 +182,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiVelopackGetLatestUpdateInfoConstMeta,
-      argValues: [],
+      argValues: [channel],
       apiImpl: this,
     ));
   }
@@ -185,7 +190,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
   TaskConstMeta get kCrateApiVelopackGetLatestUpdateInfoConstMeta =>
       const TaskConstMeta(
         debugName: "get_latest_update_info",
-        argNames: [],
+        argNames: ["channel"],
       );
 
   @override
@@ -212,11 +217,14 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
       );
 
   @override
-  Future<void> crateApiVelopackInitVelopack({required String url}) {
+  Future<void> crateApiVelopackInitVelopack(
+      {required String url, String? channel, required bool allowDowngrade}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_String(url, serializer);
+        sse_encode_opt_String(channel, serializer);
+        sse_encode_bool(allowDowngrade, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
             funcId: 5, port: port_);
       },
@@ -225,7 +233,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiVelopackInitVelopackConstMeta,
-      argValues: [url],
+      argValues: [url, channel, allowDowngrade],
       apiImpl: this,
     ));
   }
@@ -233,14 +241,15 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
   TaskConstMeta get kCrateApiVelopackInitVelopackConstMeta =>
       const TaskConstMeta(
         debugName: "init_velopack",
-        argNames: ["url"],
+        argNames: ["url", "channel", "allowDowngrade"],
       );
 
   @override
-  Future<bool> crateApiVelopackIsUpdateAvailable() {
+  Future<bool> crateApiVelopackIsUpdateAvailable({String? channel}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_opt_String(channel, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
             funcId: 6, port: port_);
       },
@@ -249,7 +258,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiVelopackIsUpdateAvailableConstMeta,
-      argValues: [],
+      argValues: [channel],
       apiImpl: this,
     ));
   }
@@ -257,14 +266,15 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
   TaskConstMeta get kCrateApiVelopackIsUpdateAvailableConstMeta =>
       const TaskConstMeta(
         debugName: "is_update_available",
-        argNames: [],
+        argNames: ["channel"],
       );
 
   @override
-  Future<void> crateApiVelopackUpdateAndExit() {
+  Future<void> crateApiVelopackUpdateAndExit({String? channel}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_opt_String(channel, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
             funcId: 7, port: port_);
       },
@@ -273,7 +283,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiVelopackUpdateAndExitConstMeta,
-      argValues: [],
+      argValues: [channel],
       apiImpl: this,
     ));
   }
@@ -281,14 +291,15 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
   TaskConstMeta get kCrateApiVelopackUpdateAndExitConstMeta =>
       const TaskConstMeta(
         debugName: "update_and_exit",
-        argNames: [],
+        argNames: ["channel"],
       );
 
   @override
-  Future<void> crateApiVelopackUpdateAndRestart() {
+  Future<void> crateApiVelopackUpdateAndRestart({String? channel}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
+        sse_encode_opt_String(channel, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
             funcId: 8, port: port_);
       },
@@ -297,7 +308,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiVelopackUpdateAndRestartConstMeta,
-      argValues: [],
+      argValues: [channel],
       apiImpl: this,
     ));
   }
@@ -305,17 +316,18 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
   TaskConstMeta get kCrateApiVelopackUpdateAndRestartConstMeta =>
       const TaskConstMeta(
         debugName: "update_and_restart",
-        argNames: [],
+        argNames: ["channel"],
       );
 
   @override
   Future<void> crateApiVelopackWaitExitThenUpdate(
-      {required bool silent, required bool restart}) {
+      {required bool silent, required bool restart, String? channel}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bool(silent, serializer);
         sse_encode_bool(restart, serializer);
+        sse_encode_opt_String(channel, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
             funcId: 9, port: port_);
       },
@@ -324,7 +336,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiVelopackWaitExitThenUpdateConstMeta,
-      argValues: [silent, restart],
+      argValues: [silent, restart, channel],
       apiImpl: this,
     ));
   }
@@ -332,7 +344,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
   TaskConstMeta get kCrateApiVelopackWaitExitThenUpdateConstMeta =>
       const TaskConstMeta(
         debugName: "wait_exit_then_update",
-        argNames: ["silent", "restart"],
+        argNames: ["silent", "restart", "channel"],
       );
 
   @protected
@@ -387,6 +399,12 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
   List<VelopackAsset> dco_decode_list_velopack_asset(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_velopack_asset).toList();
+  }
+
+  @protected
+  String? dco_decode_opt_String(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_String(raw);
   }
 
   @protected
@@ -516,6 +534,17 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
       ans_.add(sse_decode_velopack_asset(deserializer));
     }
     return ans_;
+  }
+
+  @protected
+  String? sse_decode_opt_String(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_String(deserializer));
+    } else {
+      return null;
+    }
   }
 
   @protected
@@ -671,6 +700,16 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
     sse_encode_i_32(self.length, serializer);
     for (final item in self) {
       sse_encode_velopack_asset(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_String(String? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_String(self, serializer);
     }
   }
 

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -84,25 +84,32 @@ class VelopackRustLib extends BaseEntrypoint<VelopackRustLibApi,
 
 abstract class VelopackRustLibApi extends BaseApi {
   Stream<int> crateApiVelopackCheckAndDownloadUpdatesWithProgress(
-      {String? channel});
+      {String? channel, bool? allowDowngrade});
 
   Future<String> crateApiVelopackCurrentVersion();
 
-  Future<UpdateInfo?> crateApiVelopackGetLatestUpdateInfo({String? channel});
+  Future<UpdateInfo?> crateApiVelopackGetLatestUpdateInfo(
+      {String? channel, bool? allowDowngrade});
 
   Future<void> crateApiVelopackInitApp();
 
   Future<void> crateApiVelopackInitVelopack(
       {required String url, String? channel, required bool allowDowngrade});
 
-  Future<bool> crateApiVelopackIsUpdateAvailable({String? channel});
+  Future<bool> crateApiVelopackIsUpdateAvailable(
+      {String? channel, bool? allowDowngrade});
 
-  Future<void> crateApiVelopackUpdateAndExit({String? channel});
+  Future<void> crateApiVelopackUpdateAndExit(
+      {String? channel, bool? allowDowngrade});
 
-  Future<void> crateApiVelopackUpdateAndRestart({String? channel});
+  Future<void> crateApiVelopackUpdateAndRestart(
+      {String? channel, bool? allowDowngrade});
 
   Future<void> crateApiVelopackWaitExitThenUpdate(
-      {required bool silent, required bool restart, String? channel});
+      {required bool silent,
+      required bool restart,
+      String? channel,
+      bool? allowDowngrade});
 }
 
 class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
@@ -116,13 +123,14 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
 
   @override
   Stream<int> crateApiVelopackCheckAndDownloadUpdatesWithProgress(
-      {String? channel}) {
+      {String? channel, bool? allowDowngrade}) {
     final progressSink = RustStreamSink<int>();
     unawaited(handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_StreamSink_i_16_Sse(progressSink, serializer);
         sse_encode_opt_String(channel, serializer);
+        sse_encode_opt_box_autoadd_bool(allowDowngrade, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
             funcId: 1, port: port_);
       },
@@ -131,7 +139,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiVelopackCheckAndDownloadUpdatesWithProgressConstMeta,
-      argValues: [progressSink, channel],
+      argValues: [progressSink, channel, allowDowngrade],
       apiImpl: this,
     )));
     return progressSink.stream;
@@ -141,7 +149,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
       get kCrateApiVelopackCheckAndDownloadUpdatesWithProgressConstMeta =>
           const TaskConstMeta(
             debugName: "check_and_download_updates_with_progress",
-            argNames: ["progressSink", "channel"],
+            argNames: ["progressSink", "channel", "allowDowngrade"],
           );
 
   @override
@@ -169,11 +177,13 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
       );
 
   @override
-  Future<UpdateInfo?> crateApiVelopackGetLatestUpdateInfo({String? channel}) {
+  Future<UpdateInfo?> crateApiVelopackGetLatestUpdateInfo(
+      {String? channel, bool? allowDowngrade}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_String(channel, serializer);
+        sse_encode_opt_box_autoadd_bool(allowDowngrade, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
             funcId: 3, port: port_);
       },
@@ -182,7 +192,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiVelopackGetLatestUpdateInfoConstMeta,
-      argValues: [channel],
+      argValues: [channel, allowDowngrade],
       apiImpl: this,
     ));
   }
@@ -190,7 +200,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
   TaskConstMeta get kCrateApiVelopackGetLatestUpdateInfoConstMeta =>
       const TaskConstMeta(
         debugName: "get_latest_update_info",
-        argNames: ["channel"],
+        argNames: ["channel", "allowDowngrade"],
       );
 
   @override
@@ -245,11 +255,13 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
       );
 
   @override
-  Future<bool> crateApiVelopackIsUpdateAvailable({String? channel}) {
+  Future<bool> crateApiVelopackIsUpdateAvailable(
+      {String? channel, bool? allowDowngrade}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_String(channel, serializer);
+        sse_encode_opt_box_autoadd_bool(allowDowngrade, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
             funcId: 6, port: port_);
       },
@@ -258,7 +270,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiVelopackIsUpdateAvailableConstMeta,
-      argValues: [channel],
+      argValues: [channel, allowDowngrade],
       apiImpl: this,
     ));
   }
@@ -266,15 +278,17 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
   TaskConstMeta get kCrateApiVelopackIsUpdateAvailableConstMeta =>
       const TaskConstMeta(
         debugName: "is_update_available",
-        argNames: ["channel"],
+        argNames: ["channel", "allowDowngrade"],
       );
 
   @override
-  Future<void> crateApiVelopackUpdateAndExit({String? channel}) {
+  Future<void> crateApiVelopackUpdateAndExit(
+      {String? channel, bool? allowDowngrade}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_String(channel, serializer);
+        sse_encode_opt_box_autoadd_bool(allowDowngrade, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
             funcId: 7, port: port_);
       },
@@ -283,7 +297,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiVelopackUpdateAndExitConstMeta,
-      argValues: [channel],
+      argValues: [channel, allowDowngrade],
       apiImpl: this,
     ));
   }
@@ -291,15 +305,17 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
   TaskConstMeta get kCrateApiVelopackUpdateAndExitConstMeta =>
       const TaskConstMeta(
         debugName: "update_and_exit",
-        argNames: ["channel"],
+        argNames: ["channel", "allowDowngrade"],
       );
 
   @override
-  Future<void> crateApiVelopackUpdateAndRestart({String? channel}) {
+  Future<void> crateApiVelopackUpdateAndRestart(
+      {String? channel, bool? allowDowngrade}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_opt_String(channel, serializer);
+        sse_encode_opt_box_autoadd_bool(allowDowngrade, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
             funcId: 8, port: port_);
       },
@@ -308,7 +324,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiVelopackUpdateAndRestartConstMeta,
-      argValues: [channel],
+      argValues: [channel, allowDowngrade],
       apiImpl: this,
     ));
   }
@@ -316,18 +332,22 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
   TaskConstMeta get kCrateApiVelopackUpdateAndRestartConstMeta =>
       const TaskConstMeta(
         debugName: "update_and_restart",
-        argNames: ["channel"],
+        argNames: ["channel", "allowDowngrade"],
       );
 
   @override
   Future<void> crateApiVelopackWaitExitThenUpdate(
-      {required bool silent, required bool restart, String? channel}) {
+      {required bool silent,
+      required bool restart,
+      String? channel,
+      bool? allowDowngrade}) {
     return handler.executeNormal(NormalTask(
       callFfi: (port_) {
         final serializer = SseSerializer(generalizedFrbRustBinding);
         sse_encode_bool(silent, serializer);
         sse_encode_bool(restart, serializer);
         sse_encode_opt_String(channel, serializer);
+        sse_encode_opt_box_autoadd_bool(allowDowngrade, serializer);
         pdeCallFfi(generalizedFrbRustBinding, serializer,
             funcId: 9, port: port_);
       },
@@ -336,7 +356,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
         decodeErrorData: sse_decode_AnyhowException,
       ),
       constMeta: kCrateApiVelopackWaitExitThenUpdateConstMeta,
-      argValues: [silent, restart, channel],
+      argValues: [silent, restart, channel, allowDowngrade],
       apiImpl: this,
     ));
   }
@@ -344,7 +364,7 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
   TaskConstMeta get kCrateApiVelopackWaitExitThenUpdateConstMeta =>
       const TaskConstMeta(
         debugName: "wait_exit_then_update",
-        argNames: ["silent", "restart", "channel"],
+        argNames: ["silent", "restart", "channel", "allowDowngrade"],
       );
 
   @protected
@@ -367,6 +387,12 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
 
   @protected
   bool dco_decode_bool(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw as bool;
+  }
+
+  @protected
+  bool dco_decode_box_autoadd_bool(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as bool;
   }
@@ -405,6 +431,12 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
   String? dco_decode_opt_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_String(raw);
+  }
+
+  @protected
+  bool? dco_decode_opt_box_autoadd_bool(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_box_autoadd_bool(raw);
   }
 
   @protected
@@ -498,6 +530,12 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
   }
 
   @protected
+  bool sse_decode_box_autoadd_bool(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return (sse_decode_bool(deserializer));
+  }
+
+  @protected
   UpdateInfo sse_decode_box_autoadd_update_info(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_update_info(deserializer));
@@ -542,6 +580,17 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
 
     if (sse_decode_bool(deserializer)) {
       return (sse_decode_String(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  bool? sse_decode_opt_box_autoadd_bool(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_box_autoadd_bool(deserializer));
     } else {
       return null;
     }
@@ -666,6 +715,12 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
   }
 
   @protected
+  void sse_encode_box_autoadd_bool(bool self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_bool(self, serializer);
+  }
+
+  @protected
   void sse_encode_box_autoadd_update_info(
       UpdateInfo self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -710,6 +765,16 @@ class VelopackRustLibApiImpl extends VelopackRustLibApiImplPlatform
     sse_encode_bool(self != null, serializer);
     if (self != null) {
       sse_encode_String(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_box_autoadd_bool(bool? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_box_autoadd_bool(self, serializer);
     }
   }
 

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -33,6 +33,9 @@ abstract class VelopackRustLibApiImplPlatform
   bool dco_decode_bool(dynamic raw);
 
   @protected
+  bool dco_decode_box_autoadd_bool(dynamic raw);
+
+  @protected
   UpdateInfo dco_decode_box_autoadd_update_info(dynamic raw);
 
   @protected
@@ -49,6 +52,9 @@ abstract class VelopackRustLibApiImplPlatform
 
   @protected
   String? dco_decode_opt_String(dynamic raw);
+
+  @protected
+  bool? dco_decode_opt_box_autoadd_bool(dynamic raw);
 
   @protected
   UpdateInfo? dco_decode_opt_box_autoadd_update_info(dynamic raw);
@@ -85,6 +91,9 @@ abstract class VelopackRustLibApiImplPlatform
   bool sse_decode_bool(SseDeserializer deserializer);
 
   @protected
+  bool sse_decode_box_autoadd_bool(SseDeserializer deserializer);
+
+  @protected
   UpdateInfo sse_decode_box_autoadd_update_info(SseDeserializer deserializer);
 
   @protected
@@ -103,6 +112,9 @@ abstract class VelopackRustLibApiImplPlatform
 
   @protected
   String? sse_decode_opt_String(SseDeserializer deserializer);
+
+  @protected
+  bool? sse_decode_opt_box_autoadd_bool(SseDeserializer deserializer);
 
   @protected
   UpdateInfo? sse_decode_opt_box_autoadd_update_info(
@@ -145,6 +157,9 @@ abstract class VelopackRustLibApiImplPlatform
   void sse_encode_bool(bool self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_bool(bool self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_update_info(
       UpdateInfo self, SseSerializer serializer);
 
@@ -165,6 +180,9 @@ abstract class VelopackRustLibApiImplPlatform
 
   @protected
   void sse_encode_opt_String(String? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_box_autoadd_bool(bool? self, SseSerializer serializer);
 
   @protected
   void sse_encode_opt_box_autoadd_update_info(

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -48,6 +48,9 @@ abstract class VelopackRustLibApiImplPlatform
   List<VelopackAsset> dco_decode_list_velopack_asset(dynamic raw);
 
   @protected
+  String? dco_decode_opt_String(dynamic raw);
+
+  @protected
   UpdateInfo? dco_decode_opt_box_autoadd_update_info(dynamic raw);
 
   @protected
@@ -97,6 +100,9 @@ abstract class VelopackRustLibApiImplPlatform
   @protected
   List<VelopackAsset> sse_decode_list_velopack_asset(
       SseDeserializer deserializer);
+
+  @protected
+  String? sse_decode_opt_String(SseDeserializer deserializer);
 
   @protected
   UpdateInfo? sse_decode_opt_box_autoadd_update_info(
@@ -156,6 +162,9 @@ abstract class VelopackRustLibApiImplPlatform
   @protected
   void sse_encode_list_velopack_asset(
       List<VelopackAsset> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_String(String? self, SseSerializer serializer);
 
   @protected
   void sse_encode_opt_box_autoadd_update_info(

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -35,6 +35,9 @@ abstract class VelopackRustLibApiImplPlatform
   bool dco_decode_bool(dynamic raw);
 
   @protected
+  bool dco_decode_box_autoadd_bool(dynamic raw);
+
+  @protected
   UpdateInfo dco_decode_box_autoadd_update_info(dynamic raw);
 
   @protected
@@ -51,6 +54,9 @@ abstract class VelopackRustLibApiImplPlatform
 
   @protected
   String? dco_decode_opt_String(dynamic raw);
+
+  @protected
+  bool? dco_decode_opt_box_autoadd_bool(dynamic raw);
 
   @protected
   UpdateInfo? dco_decode_opt_box_autoadd_update_info(dynamic raw);
@@ -87,6 +93,9 @@ abstract class VelopackRustLibApiImplPlatform
   bool sse_decode_bool(SseDeserializer deserializer);
 
   @protected
+  bool sse_decode_box_autoadd_bool(SseDeserializer deserializer);
+
+  @protected
   UpdateInfo sse_decode_box_autoadd_update_info(SseDeserializer deserializer);
 
   @protected
@@ -105,6 +114,9 @@ abstract class VelopackRustLibApiImplPlatform
 
   @protected
   String? sse_decode_opt_String(SseDeserializer deserializer);
+
+  @protected
+  bool? sse_decode_opt_box_autoadd_bool(SseDeserializer deserializer);
 
   @protected
   UpdateInfo? sse_decode_opt_box_autoadd_update_info(
@@ -147,6 +159,9 @@ abstract class VelopackRustLibApiImplPlatform
   void sse_encode_bool(bool self, SseSerializer serializer);
 
   @protected
+  void sse_encode_box_autoadd_bool(bool self, SseSerializer serializer);
+
+  @protected
   void sse_encode_box_autoadd_update_info(
       UpdateInfo self, SseSerializer serializer);
 
@@ -167,6 +182,9 @@ abstract class VelopackRustLibApiImplPlatform
 
   @protected
   void sse_encode_opt_String(String? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_box_autoadd_bool(bool? self, SseSerializer serializer);
 
   @protected
   void sse_encode_opt_box_autoadd_update_info(

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -50,6 +50,9 @@ abstract class VelopackRustLibApiImplPlatform
   List<VelopackAsset> dco_decode_list_velopack_asset(dynamic raw);
 
   @protected
+  String? dco_decode_opt_String(dynamic raw);
+
+  @protected
   UpdateInfo? dco_decode_opt_box_autoadd_update_info(dynamic raw);
 
   @protected
@@ -99,6 +102,9 @@ abstract class VelopackRustLibApiImplPlatform
   @protected
   List<VelopackAsset> sse_decode_list_velopack_asset(
       SseDeserializer deserializer);
+
+  @protected
+  String? sse_decode_opt_String(SseDeserializer deserializer);
 
   @protected
   UpdateInfo? sse_decode_opt_box_autoadd_update_info(
@@ -158,6 +164,9 @@ abstract class VelopackRustLibApiImplPlatform
   @protected
   void sse_encode_list_velopack_asset(
       List<VelopackAsset> self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_String(String? self, SseSerializer serializer);
 
   @protected
   void sse_encode_opt_box_autoadd_update_info(

--- a/lib/velopack_flutter.dart
+++ b/lib/velopack_flutter.dart
@@ -5,7 +5,26 @@ export 'src/rust/api/velopack.dart' hide initVelopack;
 export 'src/rust/core/dart_types.dart';
 export 'src/rust/frb_generated.dart' show VelopackRustLib;
 
-Future<void> initializeVelopack({required String url}) async {
+/// Initializes the Velopack bridge and configures the update source.
+///
+/// [url] is the update server URL.
+///
+/// [channel] overrides the channel that updates are fetched from. When `null`,
+/// the channel the app was installed from is used.
+///
+/// [allowDowngrade] must be `true` to migrate to a version lower than the
+/// current one. This is required when switching to a channel whose latest
+/// version is older than the installed version. Switching channels takes effect
+/// on the next launch, so persist the desired channel and restart the app.
+Future<void> initializeVelopack({
+  required String url,
+  String? channel,
+  bool allowDowngrade = false,
+}) async {
   await VelopackRustLib.init();
-  await velopack_api.initVelopack(url: url);
+  await velopack_api.initVelopack(
+    url: url,
+    channel: channel,
+    allowDowngrade: allowDowngrade,
+  );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: velopack_flutter
 description: "A flutter implementation of Velopack to enable easy distribution and auto-updates for flutter apps"
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/GigaDroid/velopack_flutter
 homepage: https://velopack.io/
 environment:

--- a/rust/src/api/velopack.rs
+++ b/rust/src/api/velopack.rs
@@ -3,11 +3,24 @@ use std::sync::OnceLock;
 
 use anyhow::{bail, Result};
 use flutter_rust_bridge::frb;
-use velopack::{sources, Error, UpdateCheck, UpdateInfo, UpdateManager, VelopackApp};
+use velopack::{
+    sources, Error, UpdateCheck, UpdateInfo, UpdateManager, UpdateOptions, VelopackApp,
+};
 
 use crate::frb_generated::StreamSink;
 
-static VELOPACK_URL: OnceLock<String> = OnceLock::new();
+struct VelopackConfig {
+    url: String,
+    /// Overrides the channel that updates are fetched from. When `None`, the
+    /// channel the app was installed from is used.
+    channel: Option<String>,
+    /// Must be `true` to migrate to a version lower than the current one. This is
+    /// required when switching to a channel whose latest version is older than
+    /// the installed version.
+    allow_downgrade: bool,
+}
+
+static VELOPACK_CONFIG: OnceLock<VelopackConfig> = OnceLock::new();
 
 #[frb(init)]
 pub fn init_app() {
@@ -15,9 +28,15 @@ pub fn init_app() {
     VelopackApp::build().run();
 }
 
-pub fn init_velopack(url: String) -> Result<()> {
-    if let Err(url) = VELOPACK_URL.set(url) {
-        if VELOPACK_URL.get() == Some(&url) {
+pub fn init_velopack(url: String, channel: Option<String>, allow_downgrade: bool) -> Result<()> {
+    let config = VelopackConfig {
+        url,
+        channel,
+        allow_downgrade,
+    };
+
+    if let Err(config) = VELOPACK_CONFIG.set(config) {
+        if VELOPACK_CONFIG.get().map(|c| &c.url) == Some(&config.url) {
             return Ok(());
         }
 
@@ -27,22 +46,32 @@ pub fn init_velopack(url: String) -> Result<()> {
     Ok(())
 }
 
-fn get_update_manager() -> Result<UpdateManager, Error> {
-    let url = VELOPACK_URL.get().ok_or(Error::Other(
+/// Builds an `UpdateManager` for the configured update source.
+///
+/// When `channel` is `Some`, it overrides the channel set at initialization for
+/// this call only; when `None`, the channel from `initializeVelopack` (or the
+/// install channel) is used.
+fn get_update_manager(channel: Option<String>) -> Result<UpdateManager, Error> {
+    let config = VELOPACK_CONFIG.get().ok_or(Error::Other(
         "Velopack not initialized. Call initializeVelopack() first.".into(),
     ))?;
-    let source = sources::HttpSource::new(url);
-    UpdateManager::new(source, None, None)
+    let source = sources::HttpSource::new(&config.url);
+    let options = UpdateOptions {
+        AllowVersionDowngrade: config.allow_downgrade,
+        ExplicitChannel: channel.or_else(|| config.channel.clone()),
+        ..Default::default()
+    };
+    UpdateManager::new(source, Some(options), None)
 }
 
-pub fn is_update_available() -> Result<bool> {
-    let um = get_update_manager()?;
+pub fn is_update_available(channel: Option<String>) -> Result<bool> {
+    let um = get_update_manager(channel)?;
     let update_check = um.check_for_updates()?;
     Ok(matches!(update_check, UpdateCheck::UpdateAvailable(..)))
 }
 
-pub fn get_latest_update_info() -> Result<Option<UpdateInfo>> {
-    let um = get_update_manager()?;
+pub fn get_latest_update_info(channel: Option<String>) -> Result<Option<UpdateInfo>> {
+    let um = get_update_manager(channel)?;
     let update_check = um.check_for_updates()?;
     return match update_check {
         UpdateCheck::UpdateAvailable(updates) => Ok(Some(*updates)),
@@ -51,15 +80,16 @@ pub fn get_latest_update_info() -> Result<Option<UpdateInfo>> {
 }
 
 pub fn current_version() -> Result<String> {
-    let um = get_update_manager()?;
+    let um = get_update_manager(None)?;
     Ok(um.get_current_version_as_string())
 }
 
 pub fn check_and_download_updates_with_progress(
     progress_sink: StreamSink<i16>,
+    channel: Option<String>,
 ) -> Result<Option<UpdateInfo>> {
-    let um = get_update_manager()?;
-    if let UpdateCheck::UpdateAvailable(updates) = um.check_for_updates().unwrap() {
+    let um = get_update_manager(channel)?;
+    if let UpdateCheck::UpdateAvailable(updates) = um.check_for_updates()? {
         // Create a channel for progress messages
         let (sx, rx) = mpsc::channel();
 
@@ -77,9 +107,9 @@ pub fn check_and_download_updates_with_progress(
     }
 }
 
-fn check_and_download_updates() -> Result<Option<UpdateInfo>> {
-    let um = get_update_manager()?;
-    if let UpdateCheck::UpdateAvailable(updates) = um.check_for_updates().unwrap() {
+fn check_and_download_updates(channel: Option<String>) -> Result<Option<UpdateInfo>> {
+    let um = get_update_manager(channel)?;
+    if let UpdateCheck::UpdateAvailable(updates) = um.check_for_updates()? {
         um.download_updates(&updates, None)?;
         Ok(Some(*updates))
     } else {
@@ -87,25 +117,25 @@ fn check_and_download_updates() -> Result<Option<UpdateInfo>> {
     }
 }
 
-pub fn update_and_restart() -> Result<()> {
-    if let Some(updates) = check_and_download_updates()? {
-        let um = get_update_manager()?;
+pub fn update_and_restart(channel: Option<String>) -> Result<()> {
+    if let Some(updates) = check_and_download_updates(channel.clone())? {
+        let um = get_update_manager(channel)?;
         um.apply_updates_and_restart(&updates)?;
     }
     Ok(())
 }
 
-pub fn update_and_exit() -> Result<()> {
-    if let Some(updates) = check_and_download_updates()? {
-        let um = get_update_manager()?;
+pub fn update_and_exit(channel: Option<String>) -> Result<()> {
+    if let Some(updates) = check_and_download_updates(channel.clone())? {
+        let um = get_update_manager(channel)?;
         um.apply_updates_and_exit(&updates)?;
     }
     Ok(())
 }
 
-pub fn wait_exit_then_update(silent: bool, restart: bool) -> Result<()> {
-    if let Some(updates) = check_and_download_updates()? {
-        let um = get_update_manager()?;
+pub fn wait_exit_then_update(silent: bool, restart: bool, channel: Option<String>) -> Result<()> {
+    if let Some(updates) = check_and_download_updates(channel.clone())? {
+        let um = get_update_manager(channel)?;
         um.wait_exit_then_apply_updates(&updates, silent, restart, [""])?;
     }
     Ok(())

--- a/rust/src/api/velopack.rs
+++ b/rust/src/api/velopack.rs
@@ -51,27 +51,38 @@ pub fn init_velopack(url: String, channel: Option<String>, allow_downgrade: bool
 /// When `channel` is `Some`, it overrides the channel set at initialization for
 /// this call only; when `None`, the channel from `initializeVelopack` (or the
 /// install channel) is used.
-fn get_update_manager(channel: Option<String>) -> Result<UpdateManager, Error> {
+///
+/// When `allow_downgrade` is `Some`, it overrides the downgrade policy set at
+/// initialization for this call only; when `None`, the value from
+/// `initializeVelopack` is used. This is needed when switching to a channel
+/// whose latest version is older than the installed version.
+fn get_update_manager(
+    channel: Option<String>,
+    allow_downgrade: Option<bool>,
+) -> Result<UpdateManager, Error> {
     let config = VELOPACK_CONFIG.get().ok_or(Error::Other(
         "Velopack not initialized. Call initializeVelopack() first.".into(),
     ))?;
     let source = sources::HttpSource::new(&config.url);
     let options = UpdateOptions {
-        AllowVersionDowngrade: config.allow_downgrade,
+        AllowVersionDowngrade: allow_downgrade.unwrap_or(config.allow_downgrade),
         ExplicitChannel: channel.or_else(|| config.channel.clone()),
         ..Default::default()
     };
     UpdateManager::new(source, Some(options), None)
 }
 
-pub fn is_update_available(channel: Option<String>) -> Result<bool> {
-    let um = get_update_manager(channel)?;
+pub fn is_update_available(channel: Option<String>, allow_downgrade: Option<bool>) -> Result<bool> {
+    let um = get_update_manager(channel, allow_downgrade)?;
     let update_check = um.check_for_updates()?;
     Ok(matches!(update_check, UpdateCheck::UpdateAvailable(..)))
 }
 
-pub fn get_latest_update_info(channel: Option<String>) -> Result<Option<UpdateInfo>> {
-    let um = get_update_manager(channel)?;
+pub fn get_latest_update_info(
+    channel: Option<String>,
+    allow_downgrade: Option<bool>,
+) -> Result<Option<UpdateInfo>> {
+    let um = get_update_manager(channel, allow_downgrade)?;
     let update_check = um.check_for_updates()?;
     return match update_check {
         UpdateCheck::UpdateAvailable(updates) => Ok(Some(*updates)),
@@ -80,15 +91,16 @@ pub fn get_latest_update_info(channel: Option<String>) -> Result<Option<UpdateIn
 }
 
 pub fn current_version() -> Result<String> {
-    let um = get_update_manager(None)?;
+    let um = get_update_manager(None, None)?;
     Ok(um.get_current_version_as_string())
 }
 
 pub fn check_and_download_updates_with_progress(
     progress_sink: StreamSink<i16>,
     channel: Option<String>,
+    allow_downgrade: Option<bool>,
 ) -> Result<Option<UpdateInfo>> {
-    let um = get_update_manager(channel)?;
+    let um = get_update_manager(channel, allow_downgrade)?;
     if let UpdateCheck::UpdateAvailable(updates) = um.check_for_updates()? {
         // Create a channel for progress messages
         let (sx, rx) = mpsc::channel();
@@ -107,8 +119,11 @@ pub fn check_and_download_updates_with_progress(
     }
 }
 
-fn check_and_download_updates(channel: Option<String>) -> Result<Option<UpdateInfo>> {
-    let um = get_update_manager(channel)?;
+fn check_and_download_updates(
+    channel: Option<String>,
+    allow_downgrade: Option<bool>,
+) -> Result<Option<UpdateInfo>> {
+    let um = get_update_manager(channel, allow_downgrade)?;
     if let UpdateCheck::UpdateAvailable(updates) = um.check_for_updates()? {
         um.download_updates(&updates, None)?;
         Ok(Some(*updates))
@@ -117,25 +132,30 @@ fn check_and_download_updates(channel: Option<String>) -> Result<Option<UpdateIn
     }
 }
 
-pub fn update_and_restart(channel: Option<String>) -> Result<()> {
-    if let Some(updates) = check_and_download_updates(channel.clone())? {
-        let um = get_update_manager(channel)?;
+pub fn update_and_restart(channel: Option<String>, allow_downgrade: Option<bool>) -> Result<()> {
+    if let Some(updates) = check_and_download_updates(channel.clone(), allow_downgrade)? {
+        let um = get_update_manager(channel, allow_downgrade)?;
         um.apply_updates_and_restart(&updates)?;
     }
     Ok(())
 }
 
-pub fn update_and_exit(channel: Option<String>) -> Result<()> {
-    if let Some(updates) = check_and_download_updates(channel.clone())? {
-        let um = get_update_manager(channel)?;
+pub fn update_and_exit(channel: Option<String>, allow_downgrade: Option<bool>) -> Result<()> {
+    if let Some(updates) = check_and_download_updates(channel.clone(), allow_downgrade)? {
+        let um = get_update_manager(channel, allow_downgrade)?;
         um.apply_updates_and_exit(&updates)?;
     }
     Ok(())
 }
 
-pub fn wait_exit_then_update(silent: bool, restart: bool, channel: Option<String>) -> Result<()> {
-    if let Some(updates) = check_and_download_updates(channel.clone())? {
-        let um = get_update_manager(channel)?;
+pub fn wait_exit_then_update(
+    silent: bool,
+    restart: bool,
+    channel: Option<String>,
+    allow_downgrade: Option<bool>,
+) -> Result<()> {
+    if let Some(updates) = check_and_download_updates(channel.clone(), allow_downgrade)? {
+        let um = get_update_manager(channel, allow_downgrade)?;
         um.wait_exit_then_apply_updates(&updates, silent, restart, [""])?;
     }
     Ok(())

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -72,6 +72,7 @@ fn wire__crate__api__velopack__check_and_download_updates_with_progress_impl(
                     &mut deserializer,
                 );
             let api_channel = <Option<String>>::sse_decode(&mut deserializer);
+            let api_allow_downgrade = <Option<bool>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
@@ -80,6 +81,7 @@ fn wire__crate__api__velopack__check_and_download_updates_with_progress_impl(
                             crate::api::velopack::check_and_download_updates_with_progress(
                                 api_progress_sink,
                                 api_channel,
+                                api_allow_downgrade,
                             )?;
                         Ok(output_ok)
                     })(),
@@ -145,11 +147,15 @@ fn wire__crate__api__velopack__get_latest_update_info_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_channel = <Option<String>>::sse_decode(&mut deserializer);
+            let api_allow_downgrade = <Option<bool>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || {
-                        let output_ok = crate::api::velopack::get_latest_update_info(api_channel)?;
+                        let output_ok = crate::api::velopack::get_latest_update_info(
+                            api_channel,
+                            api_allow_downgrade,
+                        )?;
                         Ok(output_ok)
                     })(),
                 )
@@ -255,11 +261,15 @@ fn wire__crate__api__velopack__is_update_available_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_channel = <Option<String>>::sse_decode(&mut deserializer);
+            let api_allow_downgrade = <Option<bool>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || {
-                        let output_ok = crate::api::velopack::is_update_available(api_channel)?;
+                        let output_ok = crate::api::velopack::is_update_available(
+                            api_channel,
+                            api_allow_downgrade,
+                        )?;
                         Ok(output_ok)
                     })(),
                 )
@@ -290,11 +300,15 @@ fn wire__crate__api__velopack__update_and_exit_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_channel = <Option<String>>::sse_decode(&mut deserializer);
+            let api_allow_downgrade = <Option<bool>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || {
-                        let output_ok = crate::api::velopack::update_and_exit(api_channel)?;
+                        let output_ok = crate::api::velopack::update_and_exit(
+                            api_channel,
+                            api_allow_downgrade,
+                        )?;
                         Ok(output_ok)
                     })(),
                 )
@@ -325,11 +339,15 @@ fn wire__crate__api__velopack__update_and_restart_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_channel = <Option<String>>::sse_decode(&mut deserializer);
+            let api_allow_downgrade = <Option<bool>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || {
-                        let output_ok = crate::api::velopack::update_and_restart(api_channel)?;
+                        let output_ok = crate::api::velopack::update_and_restart(
+                            api_channel,
+                            api_allow_downgrade,
+                        )?;
                         Ok(output_ok)
                     })(),
                 )
@@ -362,6 +380,7 @@ fn wire__crate__api__velopack__wait_exit_then_update_impl(
             let api_silent = <bool>::sse_decode(&mut deserializer);
             let api_restart = <bool>::sse_decode(&mut deserializer);
             let api_channel = <Option<String>>::sse_decode(&mut deserializer);
+            let api_allow_downgrade = <Option<bool>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
@@ -370,6 +389,7 @@ fn wire__crate__api__velopack__wait_exit_then_update_impl(
                             api_silent,
                             api_restart,
                             api_channel,
+                            api_allow_downgrade,
                         )?;
                         Ok(output_ok)
                     })(),
@@ -475,6 +495,17 @@ impl SseDecode for Option<String> {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
             return Some(<String>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<bool> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<bool>::sse_decode(deserializer));
         } else {
             return None;
         }
@@ -744,6 +775,16 @@ impl SseEncode for Option<String> {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
             <String>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<bool> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <bool>::sse_encode(value, serializer);
         }
     }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -71,6 +71,7 @@ fn wire__crate__api__velopack__check_and_download_updates_with_progress_impl(
                 <StreamSink<i16, flutter_rust_bridge::for_generated::SseCodec>>::sse_decode(
                     &mut deserializer,
                 );
+            let api_channel = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
@@ -78,6 +79,7 @@ fn wire__crate__api__velopack__check_and_download_updates_with_progress_impl(
                         let output_ok =
                             crate::api::velopack::check_and_download_updates_with_progress(
                                 api_progress_sink,
+                                api_channel,
                             )?;
                         Ok(output_ok)
                     })(),
@@ -142,11 +144,12 @@ fn wire__crate__api__velopack__get_latest_update_info_impl(
             };
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_channel = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || {
-                        let output_ok = crate::api::velopack::get_latest_update_info()?;
+                        let output_ok = crate::api::velopack::get_latest_update_info(api_channel)?;
                         Ok(output_ok)
                     })(),
                 )
@@ -211,11 +214,17 @@ fn wire__crate__api__velopack__init_velopack_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_url = <String>::sse_decode(&mut deserializer);
+            let api_channel = <Option<String>>::sse_decode(&mut deserializer);
+            let api_allow_downgrade = <bool>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || {
-                        let output_ok = crate::api::velopack::init_velopack(api_url)?;
+                        let output_ok = crate::api::velopack::init_velopack(
+                            api_url,
+                            api_channel,
+                            api_allow_downgrade,
+                        )?;
                         Ok(output_ok)
                     })(),
                 )
@@ -245,11 +254,12 @@ fn wire__crate__api__velopack__is_update_available_impl(
             };
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_channel = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || {
-                        let output_ok = crate::api::velopack::is_update_available()?;
+                        let output_ok = crate::api::velopack::is_update_available(api_channel)?;
                         Ok(output_ok)
                     })(),
                 )
@@ -279,11 +289,12 @@ fn wire__crate__api__velopack__update_and_exit_impl(
             };
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_channel = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || {
-                        let output_ok = crate::api::velopack::update_and_exit()?;
+                        let output_ok = crate::api::velopack::update_and_exit(api_channel)?;
                         Ok(output_ok)
                     })(),
                 )
@@ -313,11 +324,12 @@ fn wire__crate__api__velopack__update_and_restart_impl(
             };
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_channel = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || {
-                        let output_ok = crate::api::velopack::update_and_restart()?;
+                        let output_ok = crate::api::velopack::update_and_restart(api_channel)?;
                         Ok(output_ok)
                     })(),
                 )
@@ -349,12 +361,16 @@ fn wire__crate__api__velopack__wait_exit_then_update_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_silent = <bool>::sse_decode(&mut deserializer);
             let api_restart = <bool>::sse_decode(&mut deserializer);
+            let api_channel = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>(
                     (move || {
-                        let output_ok =
-                            crate::api::velopack::wait_exit_then_update(api_silent, api_restart)?;
+                        let output_ok = crate::api::velopack::wait_exit_then_update(
+                            api_silent,
+                            api_restart,
+                            api_channel,
+                        )?;
                         Ok(output_ok)
                     })(),
                 )
@@ -451,6 +467,17 @@ impl SseDecode for Vec<crate::core::dart_types::VelopackAsset> {
             ));
         }
         return ans_;
+    }
+}
+
+impl SseDecode for Option<String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<String>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
     }
 }
 
@@ -707,6 +734,16 @@ impl SseEncode for Vec<crate::core::dart_types::VelopackAsset> {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
             <crate::core::dart_types::VelopackAsset>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <String>::sse_encode(value, serializer);
         }
     }
 }


### PR DESCRIPTION
## Motivation

We needed release **channel** support, so this PR adds it. As a follow-on, the
related update functions were updated to support checking and applying updates
across different channels.

## Changes

### Channel support
- Added a `channel` parameter to `initializeVelopack` to override the channel
  updates are fetched from. When omitted, the channel the app was installed from
  is used.
- Added `allowDowngrade` to `initializeVelopack` as an opt-in for migrating to a
  channel whose latest version is older than the installed one.

### Cross-channel functions
Added per-call `channel` and `allowDowngrade` overrides to the following
functions, so a different channel can be checked or pulled from — including
downgrades — without re-initializing:
- `isUpdateAvailable`
- `getLatestUpdateInfo`
- `checkAndDownloadUpdatesWithProgress`
- `updateAndRestart`
- `updateAndExit`
- `waitExitThenUpdate`

Each per-call override falls back to the init default when omitted. Keeping the
overrides on the check functions lets you preview with the exact condition the
apply will use, so the check and the apply never disagree.

### Side fixes
- Replaced `check_for_updates().unwrap()` with `?` in the download path to
  propagate errors instead of panicking.
- Expanded internal Rust state from `VELOPACK_URL` to a `VelopackConfig`
  (url / channel / allow_downgrade).
- Updated README with a Channels section (incl. downgrades) and refreshed
  function signatures; added CHANGELOG entry for `0.3.0`.

## Usage

```dart
// Set the default channel at init
await initializeVelopack(url: '...', channel: 'prod');

// Peek at another channel while staying on the default
final beta = await getLatestUpdateInfo(channel: 'beta');

// Switch to an older channel and accept the downgrade, just for this call
await updateAndRestart(channel: 'prod', allowDowngrade: true);
