### PR TITLE
fix: exclude mobile from rust build script because it is not supported

### DIFF
--- a/hook/build.dart
+++ b/hook/build.dart
@@ -1,8 +1,16 @@
+import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_rust/native_toolchain_rust.dart';
 
-void main(List<String> args) async {  
+void main(List<String> args) async {
   await build(args, (input, output) async {
+
+    final targetOS = input.config.code.targetOS;
+
+    if (targetOS == OS.iOS || targetOS == OS.android) {
+      return;
+    }
+
     await const RustBuilder(
       assetName: 'src/lib.rs',
       cratePath: 'rust',

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -4,7 +4,6 @@ import 'package:native_toolchain_rust/native_toolchain_rust.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {
-
     final targetOS = input.config.code.targetOS;
 
     if (targetOS == OS.iOS || targetOS == OS.android) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  code_assets: ^1.0.0
   flutter_rust_bridge: 2.11.1
   hooks: ^1.0.3
   native_toolchain_rust: ^1.0.3
@@ -21,6 +22,15 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   integration_test:
     sdk: flutter
+flutter:
+  plugin:
+    platforms:
+      linux:
+        ffiPlugin: true
+      macos:
+        ffiPlugin: true
+      windows:
+        ffiPlugin: true
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 


### PR DESCRIPTION
From official doc it is said velopack doesn't support iOS & Android, so i made exclude check for the platform that it is being compiled from and if it is mobile ( iOS or Android ) to not run the RustBuilder.

This solves https://github.com/GigaDroid/velopack_flutter/issues/12