### PR TITLE
fix: remove ffiPlugin flags to not make cocoaPods search for macos/windows/linux folders on build

### DIFF
--- a/hook/build.dart
+++ b/hook/build.dart
@@ -1,8 +1,16 @@
+import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
 import 'package:native_toolchain_rust/native_toolchain_rust.dart';
 
-void main(List<String> args) async {  
+void main(List<String> args) async {
   await build(args, (input, output) async {
+
+    final targetOS = input.config.code.targetOS;
+
+    if (targetOS == OS.iOS || targetOS == OS.android) {
+      return;
+    }
+
     await const RustBuilder(
       assetName: 'src/lib.rs',
       cratePath: 'rust',

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -4,7 +4,6 @@ import 'package:native_toolchain_rust/native_toolchain_rust.dart';
 
 void main(List<String> args) async {
   await build(args, (input, output) async {
-
     final targetOS = input.config.code.targetOS;
 
     if (targetOS == OS.iOS || targetOS == OS.android) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  code_assets: ^1.0.0
   flutter_rust_bridge: 2.11.1
   hooks: ^1.0.3
   native_toolchain_rust: ^1.0.3
@@ -21,6 +22,15 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   integration_test:
     sdk: flutter
+flutter:
+  plugin:
+    platforms:
+      linux:
+        ffiPlugin: true
+      macos:
+        ffiPlugin: true
+      windows:
+        ffiPlugin: true
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,10 @@ description: "A flutter implementation of Velopack to enable easy distribution a
 version: 0.3.0
 repository: https://github.com/GigaDroid/velopack_flutter
 homepage: https://velopack.io/
+platforms:
+  linux:
+  macos:
+  windows:
 environment:
   sdk: '>=3.6.0 <4.0.0'
   flutter: '>=3.3.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,15 +22,6 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   integration_test:
     sdk: flutter
-flutter:
-  plugin:
-    platforms:
-      linux:
-        ffiPlugin: true
-      macos:
-        ffiPlugin: true
-      windows:
-        ffiPlugin: true
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 


### PR DESCRIPTION
I've removed the ffiPlugin flags and added only platform section in order to show which platforms are supported on pub.dev